### PR TITLE
wording fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 DotKernel
+Copyright (c) 2024 Dotkernel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,11 @@
 {
   "name": "dotkernel/admin-documentation",
-  "description": "DotKernel Admin documentation markdown files.",
+  "description": "Dotkernel Admin documentation markdown files.",
   "type": "metapackage",
   "license": "MIT",
   "authors": [
     {
-      "name": "DotKernel Team",
+      "name": "Dotkernel Team",
       "email": "team@dotkernel.com"
     }
   ],

--- a/docs/book/v6/security/basic-security.md
+++ b/docs/book/v6/security/basic-security.md
@@ -1,16 +1,16 @@
 # Basic Security
 
-`dotkernel/admin` provides all necessary tools to implement safe applications, however you will need to manually make use of some of them.
+Dotkernel Admin provides all necessary tools to implement safe applications, however you will need to manually make use of some of them.
 This section will go over the provided tools and any steps you need to follow in order to use them successfully, as well as a few general considerations.
 
 ## Form Input Validation
 
-In order to create safe forms, `dotkernel/admin` makes use of [laminas/laminas-form](https://github.com/laminas/laminas-form) and [laminas/laminas-inputfilter](https://github.com/laminas/laminas-inputfilter).
+In order to create safe forms, Dotkernel Admin makes use of [laminas/laminas-form](https://github.com/laminas/laminas-form) and [laminas/laminas-inputfilter](https://github.com/laminas/laminas-inputfilter).
 All shipped forms have their inputs validated, and it is strongly recommended any custom forms added also make use of input filters to validate user input.
 
 ## Cross-Site Request Forgery Protection
 
-`dotkernel/admin` provides protection against CSRF attacks by using CSRF token creation and validation, available for all forms.
+Dotkernel Admin provides protection against CSRF attacks by using CSRF token creation and validation, available for all forms.
 
 All forms provided make use of CSRF token validation, but you must ensure to implement this step for any new forms you create.
 
@@ -41,10 +41,10 @@ Pay extra attention to the following keys, to make sure your desired values are 
 
 ## PHP Dependencies
 
-`dotkernel/admin` uses `composer` to handle PHP dependencies.
+Dotkernel Admin uses `composer` to handle PHP dependencies.
 In time, make sure to review any common vulnerabilities and exposures for your dependencies.
 
-> You may also keep an eye on the `dotkernel/admin` changelog for any updates relevant to your project.
+> You may also keep an eye on the Dotkernel Admin changelog for any updates relevant to your project.
 
 ## JavaScript Dependencies
 
@@ -65,7 +65,7 @@ Keep an eye on any vulnerabilities whenever using `npm` to install or update pac
 composer development-status
 ```
 
-- `Admin` ships with a [Laminas Continuous Integration](https://github.com/laminas/laminas-continuous-integration-action) GitHub Action,
+- Dotkernel Admin ships with a [Laminas Continuous Integration](https://github.com/laminas/laminas-continuous-integration-action) GitHub Action,
 if you are using a public repository consider keeping it in your custom applications to ensure code quality.
 
 > Read more about using [Laminas Continuous Integration](https://getlaminas.org/blog/2024-08-05-using-laminas-continuous-integration.html).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,7 +55,7 @@ nav:
       - Tutorials:
           - "Creating a book module using DotMaker": v6/tutorials/create-book-module-via-dot-maker.md
 site_name: admin
-site_description: "DotKernel Admin"
+site_description: "Dotkernel Admin"
 repo_url: "https://github.com/dotkernel/admin"
 plugins:
   - search


### PR DESCRIPTION
Updated `basic-security.md` wording of "Dotkernel Admin", also changed "DotKernel" to "Dotkernel" where found